### PR TITLE
Set correct file monitor for base image building action

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,10 +10,10 @@ on:
     tags:
     - v*
     paths:
-    - '**/Dockerfile'
+    - 'base/Dockerfile'
   pull_request_target:
     paths-ignore:
-    - '**/Dockerfile'
+    - 'base/Dockerfile'
 
 jobs:
   buildAndPush:


### PR DESCRIPTION
We will have separate actions for each docker image, so let's remove the globbing and put the correct path instead