### PR TITLE
Fix docker build action dependencies

### DIFF
--- a/.github/workflows/publish-docker-dev.yml
+++ b/.github/workflows/publish-docker-dev.yml
@@ -20,6 +20,8 @@ on:
       - 'Build and Publish Base Docker Image'
     branches:
       - main
+    tags:
+      - v*
     types:
       - completed
 

--- a/.github/workflows/publish-docker-net.yml
+++ b/.github/workflows/publish-docker-net.yml
@@ -20,6 +20,8 @@ on:
       - 'Build and Publish Base Docker Image'
     branches:
       - main
+    tags:
+      - v*
     types:
       - completed
 


### PR DESCRIPTION
Build dev/net images, when:
- the base image was built on `main` (image tag: `latest`)
- the base image was built on a version tag, such as `v0.0.13`, usually after release