### PR TITLE
Update go packages (remove `v1.22` and add `v1.24`)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -21,7 +21,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 ARG DEBIAN_FRONEND=noninteractive
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+  && apt-get install -y --no-install-recommends --ignore-missing \
     apt-transport-https bash-completion ca-certificates curl \
     debian-keyring debian-archive-keyring git gnupg htop iputils-ping iproute2 jq less \
     ncdu net-tools openssh-client socat strace telnet tcpdump tzdata tmux vim wget \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/damyan/sak-base
 USER root
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    build-essential delve gdb golang-1.22-go golang-1.23-go make python3 python3-pip \
+  && apt-get install -y --no-install-recommends --ignore-missing \
+    build-essential delve gdb golang-1.23-go golang-1.24-go make python3 python3-pip \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR "/home/damyan"

--- a/net/Dockerfile
+++ b/net/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/damyan/sak-base
 USER root
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+  && apt-get install -y --no-install-recommends --ignore-missing \
     bind9-dnsutils mtr-tiny net-tools \
     psmisc procps iperf3 tshark \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add `--ignore-missing` to apt, so non-missing packages do not break the build